### PR TITLE
support for steam guard file content as parameter

### DIFF
--- a/steampy/guard.py
+++ b/steampy/guard.py
@@ -3,13 +3,17 @@ import hmac
 import json
 import struct
 import time
+import os
 
 from hashlib import sha1
 
 
 def load_steam_guard(steam_guard: str) -> dict:
-    with open(steam_guard, 'r') as f:
-        return json.loads(f.read())
+    if os.path.isfile(steam_guard):
+        with open(steam_guard, 'r') as f:
+            return json.loads(f.read())
+    else:
+        return json.loads(steam_guard)
 
 
 def generate_one_time_code(shared_secret: str, timestamp: int = int(time.time())) -> str:


### PR DESCRIPTION
I have my bot accounts stored in a database together with their steam guard data. This change allows me to directly pass that data to steampy.