### PR TITLE
ignore casing in is_session_alive()

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -53,7 +53,7 @@ class SteamClient:
     def is_session_alive(self):
         steam_login = self.username
         main_page_response = self._session.get(SteamUrl.COMMUNITY_URL)
-        return steam_login in main_page_response.text
+        return steam_login.lower() in main_page_response.text.lower()
 
     def api_call(self, request_method: str, interface: str, api_method: str, version: str,
                  params: dict = None) -> requests.Response:


### PR DESCRIPTION
Steam login is not case sensitive with the username.
This causes is_session_alive not to work correctly when you entered your username with mixed upper- and lowercased characters.