### PR TITLE
Fixed get_my_listings getting only the first 10 listings

### DIFF
--- a/steampy/market.py
+++ b/steampy/market.py
@@ -6,7 +6,7 @@ from steampy.confirmation import ConfirmationExecutor
 from steampy.exceptions import ApiException, TooManyRequests, LoginRequired
 from steampy.models import Currency, SteamUrl, GameOptions
 from steampy.utils import text_between, get_listing_id_to_assets_address_from_html, get_market_listings_from_html, \
-    merge_items_with_descriptions_from_listing
+    merge_items_with_descriptions_from_listing, get_market_sell_listings_from_api
 
 
 def login_required(func):
@@ -52,6 +52,20 @@ class SteamMarket:
         listings = get_market_listings_from_html(response.text)
         listings = merge_items_with_descriptions_from_listing(listings, listing_id_to_assets_address,
                                                               assets_descriptions)
+        n_showing = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_end">', '</span>'))
+        n_total = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_total">', '</span>'))
+        if n_total > n_showing:
+            url = "%s/market/mylistings/render/?query=&start=%s&count=%s" % (SteamUrl.COMMUNITY_URL, n_showing, -1)
+            response = self._session.get(url)
+            if response.status_code != 200:
+                raise ApiException("There was a problem getting the listings. http code: %s" % response.status_code)
+            jresp = response.json()
+            listing_id_to_assets_address = get_listing_id_to_assets_address_from_html(jresp.get("hovers"))
+            listings_2 = get_market_sell_listings_from_api(jresp.get("results_html"))
+            listings_2 = merge_items_with_descriptions_from_listing(listings_2, listing_id_to_assets_address,
+                                                                    jresp.get("assets"))
+            listings["sell_listings"] = {**listings["sell_listings"], **listings_2["sell_listings"]}
+
         return listings
 
     @login_required

--- a/steampy/market.py
+++ b/steampy/market.py
@@ -52,19 +52,20 @@ class SteamMarket:
         listings = get_market_listings_from_html(response.text)
         listings = merge_items_with_descriptions_from_listing(listings, listing_id_to_assets_address,
                                                               assets_descriptions)
-        n_showing = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_end">', '</span>'))
-        n_total = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_total">', '</span>'))
-        if n_total > n_showing:
-            url = "%s/market/mylistings/render/?query=&start=%s&count=%s" % (SteamUrl.COMMUNITY_URL, n_showing, -1)
-            response = self._session.get(url)
-            if response.status_code != 200:
-                raise ApiException("There was a problem getting the listings. http code: %s" % response.status_code)
-            jresp = response.json()
-            listing_id_to_assets_address = get_listing_id_to_assets_address_from_html(jresp.get("hovers"))
-            listings_2 = get_market_sell_listings_from_api(jresp.get("results_html"))
-            listings_2 = merge_items_with_descriptions_from_listing(listings_2, listing_id_to_assets_address,
-                                                                    jresp.get("assets"))
-            listings["sell_listings"] = {**listings["sell_listings"], **listings_2["sell_listings"]}
+        if '<span id="tabContentsMyActiveMarketListings_end">' in response.text:
+            n_showing = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_end">', '</span>'))
+            n_total = int(text_between(response.text, '<span id="tabContentsMyActiveMarketListings_total">', '</span>'))
+            if n_total > n_showing:
+                url = "%s/market/mylistings/render/?query=&start=%s&count=%s" % (SteamUrl.COMMUNITY_URL, n_showing, -1)
+                response = self._session.get(url)
+                if response.status_code != 200:
+                    raise ApiException("There was a problem getting the listings. http code: %s" % response.status_code)
+                jresp = response.json()
+                listing_id_to_assets_address = get_listing_id_to_assets_address_from_html(jresp.get("hovers"))
+                listings_2 = get_market_sell_listings_from_api(jresp.get("results_html"))
+                listings_2 = merge_items_with_descriptions_from_listing(listings_2, listing_id_to_assets_address,
+                                                                        jresp.get("assets"))
+                listings["sell_listings"] = {**listings["sell_listings"], **listings_2["sell_listings"]}
 
         return listings
 

--- a/steampy/utils.py
+++ b/steampy/utils.py
@@ -109,6 +109,12 @@ def get_sell_listings_from_node(node: Tag) -> dict:
     return sell_listings_dict
 
 
+def get_market_sell_listings_from_api(html: str) -> dict:
+    document = BeautifulSoup(html, "html.parser")
+    sell_listings_dict = get_sell_listings_from_node(document)
+    return {"sell_listings": sell_listings_dict}
+
+
 def get_buy_orders_from_node(node: Tag) -> dict:
     buy_orders_raw = node.findAll("div", {"id": re.compile('mybuyorder_\\d+')})
     buy_orders_dict = {}


### PR DESCRIPTION
I noticed if you have more than 10 sell listings, Steam folds them in pages so inside the html there are only the first 10 listings.
To show you the others Steam simply calls an api. 

This "pagination" happens only with sell listings, if you have more that 10 buy orders or 10 sell listings waiting the confirmation they will show all together.