### PR TITLE
Only allow merging if possible

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -135,7 +135,7 @@ class SteamClient:
                   'tradeofferid': trade_offer_id,
                   'language': 'english'}
         response = self.api_call('GET', 'IEconService', 'GetTradeOffer', 'v1', params).json()
-        if merge:
+        if merge and "descriptions" in response['response']:
             descriptions = {get_description_key(offer): offer for offer in response['response']['descriptions']}
             offer = response['response']['offer']
             response['response']['offer'] = merge_items_with_descriptions_from_offer(offer, descriptions)


### PR DESCRIPTION
As soon as a trade is completed, the items get new ids which causes steam to lose track of them.
Since there is no description left for the items, get_trade_offer raises an exception when a trade is completed.

If the items are missing, steam automatically adds {"missing": True} to the first item of response['response']['offer']['items_to_receive']. So if you want to check if the items are gone, check this boolean.