### PR TITLE
Added support for receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ and descriptions merged with data are value.
 **get_trade_offer(trade_offer_id: str, merge: bool = True) -> dict**
 
 
+**get_trade_receipt(trade_id: str) -> list**
+
+Getting the receipt for a trade with all item information after the items has been traded.
+Do NOT store any item ids before you got the receipt since the ids may change.
+"trade_id" can be found in trade offers: `offer['response']['offer']['tradeid']`. Do not use ´tradeofferid´.
+
+
 **make_offer(items_from_me: List[Asset], items_from_them: List[Asset], partner_steam_id: str, message:str ='') -> dict**
 
 Using `SteamClient.login` method is required before usage

--- a/steampy/client.py
+++ b/steampy/client.py
@@ -141,7 +141,7 @@ class SteamClient:
             response['response']['offer'] = merge_items_with_descriptions_from_offer(offer, descriptions)
         return response
     
-    def get_trade_receipt(self, trade_id) -> list:
+    def get_trade_receipt(self, trade_id: str) -> list:
         html = self._session.get("https://steamcommunity.com/trade/{}/receipt".format(trade_id)).content.decode()
         items = []
         for item in texts_between(html, "oItem = ", ";\r\n\toItem"):

--- a/steampy/client.py
+++ b/steampy/client.py
@@ -130,7 +130,7 @@ class SteamClient:
             filter(lambda offer: offer['trade_offer_state'] == TradeOfferState.Active, offers_sent))
         return offers_response
 
-    def get_trade_offer(self, trade_offer_id: str, merge: bool = True) -> TradeOffer:
+    def get_trade_offer(self, trade_offer_id: str, merge: bool = True) -> dict:
         params = {'key': self._api_key,
                   'tradeofferid': trade_offer_id,
                   'language': 'english'}


### PR DESCRIPTION
get_trade offer returns a TradeOffer now. It is completely backwards compatible and has the additional method "get_receipt" which will return a list of the items you got from the trade with all new ids.