### PR TITLE
Utils.merge_items - copy description before modifying it

### DIFF
--- a/steampy/utils.py
+++ b/steampy/utils.py
@@ -1,3 +1,4 @@
+import copy
 import struct
 import urllib.parse as urlparse
 import re
@@ -77,7 +78,7 @@ def merge_items(items: List[dict], descriptions: dict, **kwargs) -> dict:
     merged_items = {}
     for item in items:
         description_key = get_description_key(item)
-        description = descriptions[description_key]
+        description = copy.copy(descriptions[description_key])
         item_id = item.get('id') or item['assetid']
         description['contextid'] = item.get('contextid') or kwargs['context_id']
         description['id'] = item_id


### PR DESCRIPTION
The items which have the same values for the keys 'classid' and 'instanceid' are the same object, meaning they share the values for the keys 'contextid', 'id', and 'amount'. That's why you should copy them before modifying.

<img width="1280" alt="1" src="https://user-images.githubusercontent.com/8964331/31642677-cbb3e1a4-b2f4-11e7-824c-4568fd7446e0.png">
<img width="697" alt="2" src="https://user-images.githubusercontent.com/8964331/31642678-cd4afbec-b2f4-11e7-8219-0b2bcdd387a0.png">
<img width="491" alt="3" src="https://user-images.githubusercontent.com/8964331/31642679-ceca60a2-b2f4-11e7-9f89-3b1cdc077bb2.png">
