### PR TITLE
Fixing mistake on the AppID for TF2

### DIFF
--- a/steampy/models.py
+++ b/steampy/models.py
@@ -7,7 +7,7 @@ class GameOptions:
 
     DOTA2 = PredefinedOptions('570', '2')
     CS = PredefinedOptions('730', '2')
-    TF2 = ('440', '2')
+    TF2 = PredefinedOptions('440', '2')
 
     def __init__(self, app_id: str, context_id: str) -> None:
         self.app_id = app_id


### PR DESCRIPTION
Just a quick edit applying the PredefinedOptions function to the TF2 AppID in the GameOptions class. 