### PR TITLE
Fix key error

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -149,10 +149,11 @@ class SteamClient:
         return items
 
     @login_required
-    def accept_trade_offer(self, trade_offer_id: str) -> dict:
-        trade = self.get_trade_offer(trade_offer_id)
-        if trade['trade_offer_state'] is not TradeOfferState.Active:
-            raise ApiException("Invalid trade offer state: {}".format(trade['trade_offer_state']))
+    def accept_trade_offer(self, trade_offer_id: str, check_offer_state: bool) -> dict:
+        if check_offer_state:
+            trade = self.get_trade_offer(trade_offer_id)
+            if trade.get('trade_offer_state', 2) is not TradeOfferState.Active.value:
+                raise ApiException("Invalid trade offer state: {}".format(trade['trade_offer_state']))
         partner = self._fetch_trade_partner_id(trade_offer_id)
         session_id = self._get_session_id()
         accept_url = SteamUrl.COMMUNITY_URL + '/tradeoffer/' + trade_offer_id + '/accept'


### PR DESCRIPTION
A KeyError can happen, when getting trade status, so use .get And default to 2, as there have been times, where my bot won't accept an active trade, due to this exception