### PR TITLE
Fixed chat messages & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,13 +444,23 @@ Default timestamp is current time.
 SteamChat methods
 ==============
 
-**send_message(steamid_64: str =, text: str) -> requests.Response**
+**send_message(steamid_64: str, text: str) -> requests.Response**
 
 Send the string contained in `text` to the desired `steamid_64`.
+`client.chat.send_message("[steamid]", "This is a message.")`
 
-**chat_poll() -> list**
+**fetch_messages() -> dict**
 
-Return a list with all messages received as dictionaries `{"from": steamid_64, "message": text}`.
+Returns a dictionary with all new sent and received messages:
+
+`{
+    'sent': [
+        {'partner': "[steamid]", 'message': "This is a message."}
+    ],
+    'received': []
+}`
+
+`client.chat.fetch_messages()`
 
 Test
 ====

--- a/README.md
+++ b/README.md
@@ -453,12 +453,14 @@ Send the string contained in `text` to the desired `steamid_64`.
 
 Returns a dictionary with all new sent and received messages:
 
-`{
+```
+{
     'sent': [
         {'partner': "[steamid]", 'message': "This is a message."}
     ],
     'received': []
-}`
+}
+```
 
 `client.chat.fetch_messages()`
 

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ SteamChat methods
 **send_message(steamid_64: str, text: str) -> requests.Response**
 
 Send the string contained in `text` to the desired `steamid_64`.
+
 `client.chat.send_message("[steamid]", "This is a message.")`
 
 **fetch_messages() -> dict**

--- a/examples/chat_bot.py
+++ b/examples/chat_bot.py
@@ -22,9 +22,9 @@ def main():
     print('Bot logged in successfully, polling messages every 10 seconds')
     while True:
         time.sleep(10)
-        messages = client.chat.fetch_messages()
+        messages = client.chat.fetch_messages()['received']
         for message in messages:
-            client.chat.send_message(message.get("from"), "Got your message: " + message.get("message"))
+            client.chat.send_message(message['partner'], "Got your message: " + message['message'])
 
 
 def are_credentials_filled() -> bool:


### PR DESCRIPTION
Fixed chat messages.
Added new method to poll all chat events (I will use this later for friend requests).
Fixed & added documentation

@bukson This breaks backwards compatibility of the current chat methods. It is required however because the old version was missing important features.
I know you asked us to review the ChatClient class before you merged it but as it turned out, it was not tested in detail.