### PR TITLE
Add price history method

### DIFF
--- a/steampy/market.py
+++ b/steampy/market.py
@@ -41,6 +41,17 @@ class SteamMarket:
         if response.status_code == 429:
             raise TooManyRequests("You can fetch maximum 20 prices in 60s period")
         return response.json()
+    
+    def fetch_price_history(self, item_hash_name: str, game: GameOptions, currency: str = Currency.USD) -> dict:
+        url = SteamUrl.COMMUNITY_URL + '/market/pricehistory/'
+        params = {'country': 'PL',
+                  'currency': currency,
+                  'appid': game.app_id,
+                  'market_hash_name': item_hash_name}
+        response = self._session.get(url, params=params)
+        if response.status_code == 429:
+            raise TooManyRequests("You can fetch maximum 20 prices in 60s period")
+        return response.json()
 
     @login_required
     def get_my_market_listings(self) -> dict:


### PR DESCRIPTION
Making a pricing algorithm using only median lowest price sometimes does not work and leads to poor performance. By adding a price history method, it is now possible to calculate trends, volatility and confidence intervals.

The data returned by the method is a list of the points used by the graph, where each point is represented by [date, price, volume].