### PR TITLE
Change decline and cancel trade offer & longer web session.

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -209,15 +209,15 @@ class SteamClient:
         return confirmation_executor.send_trade_allow_request(trade_offer_id)
 
     def decline_trade_offer(self, trade_offer_id: str) -> dict:
-        params = {'key': self._api_key,
-                  'tradeofferid': trade_offer_id}
-        return self.api_call('POST', 'IEconService', 'DeclineTradeOffer', 'v1', params).json()
+        url = 'https://steamcommunity.com/tradeoffer/' + trade_offer_id + '/decline'
+        response = self._session.post(url, data={'sessionid': self._get_session_id()})
+        return response.json()
 
     def cancel_trade_offer(self, trade_offer_id: str) -> dict:
-        params = {'key': self._api_key,
-                  'tradeofferid': trade_offer_id}
-        return self.api_call('POST', 'IEconService', 'CancelTradeOffer', 'v1', params).json()
-
+        url = 'https://steamcommunity.com/tradeoffer/' + trade_offer_id + '/cancel'
+        response = self._session.post(url, data={'sessionid': self._get_session_id()})
+        return response.json()
+    
     @login_required
     def make_offer(self, items_from_me: List[Asset], items_from_them: List[Asset], partner_steam_id: str,
                    message: str = '') -> dict:

--- a/steampy/client.py
+++ b/steampy/client.py
@@ -210,13 +210,13 @@ class SteamClient:
 
     def decline_trade_offer(self, trade_offer_id: str) -> dict:
         url = 'https://steamcommunity.com/tradeoffer/' + trade_offer_id + '/decline'
-        response = self._session.post(url, data={'sessionid': self._get_session_id()})
-        return response.json()
+        response = self._session.post(url, data={'sessionid': self._get_session_id()}).json()
+        return response
 
     def cancel_trade_offer(self, trade_offer_id: str) -> dict:
         url = 'https://steamcommunity.com/tradeoffer/' + trade_offer_id + '/cancel'
-        response = self._session.post(url, data={'sessionid': self._get_session_id()})
-        return response.json()
+        response = self._session.post(url, data={'sessionid': self._get_session_id()}).json()
+        return response
     
     @login_required
     def make_offer(self, items_from_me: List[Asset], items_from_them: List[Asset], partner_steam_id: str,

--- a/steampy/login.py
+++ b/steampy/login.py
@@ -77,7 +77,7 @@ class LoginExecutor:
             'captcha_text': '',
             'emailsteamid': '',
             'rsatimestamp': rsa_timestamp,
-            'remember_login': 'false',
+            'remember_login': 'true',
             'donotcache': str(int(time.time() * 1000))
         }
 


### PR DESCRIPTION
I have a lot of accounts to use, and get for everyone a apikey is terrible. Easier way is use it without api call. Change remember login for long-live web session to reduce relogin attempts.