### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/test_guard.py
+++ b/test/test_guard.py
@@ -15,14 +15,14 @@ class TestGuard(TestCase):
     def test_one_time_code(self):
         timestamp = 1469184207
         code = guard.generate_one_time_code(self.shared_secret, timestamp)
-        self.assertEquals(code, 'P2QJN')
+        self.assertEqual(code, 'P2QJN')
 
     def test_confirmation_key(self):
         timestamp = 1470838334
         confirmation_key = guard.generate_confirmation_key(self.identity_secret, Tag.CONF.value, timestamp)
-        self.assertEquals(confirmation_key, b'pWqjnkcwqni+t/n+5xXaEa0SGeA=')
+        self.assertEqual(confirmation_key, b'pWqjnkcwqni+t/n+5xXaEa0SGeA=')
 
     def test_generate_device_id(self):
         steam_id = "12341234123412345"
         device_id = guard.generate_device_id(steam_id)
-        self.assertEquals(device_id, "android:677cf5aa-3300-7807-d1e2-c408142742e2")
+        self.assertEqual(device_id, "android:677cf5aa-3300-7807-d1e2-c408142742e2")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,14 +9,14 @@ class TestUtils(TestCase):
     def test_text_between(self):
         text = 'var a = "dupadupa";'
         text_between = utils.text_between(text, 'var a = "', '";')
-        self.assertEquals(text_between, 'dupadupa')
+        self.assertEqual(text_between, 'dupadupa')
         
     def test_texts_between(self):
         text = "<li>element 1</li>\n<li>some random element</li>"
         items = []
         for el in utils.texts_between(text, "<li>", "</li>"):
             items.append(el)
-        self.assertEquals(items, ["element 1", "some random element"])
+        self.assertEqual(items, ["element 1", "some random element"])
 
     def test_account_id_to_steam_id(self):
         account_id = '358617487'
@@ -26,17 +26,17 @@ class TestUtils(TestCase):
     def test_steam_id_to_account_id(self):
         steam_id = '76561198318883215'
         account_id = utils.steam_id_to_account_id(steam_id)
-        self.assertEquals(account_id, '358617487')
+        self.assertEqual(account_id, '358617487')
 
     def test_parse_price_with_currency_symbol(self):
         price = '$11.33 USD'
         decimal_price = utils.parse_price(price)
-        self.assertEquals(decimal_price, decimal.Decimal('11.33'))
+        self.assertEqual(decimal_price, decimal.Decimal('11.33'))
 
     def test_parse_price_without_currency_symbol(self):
         price = '11,33 USD'
         decimal_price = utils.parse_price(price)
-        self.assertEquals(decimal_price, decimal.Decimal('11.33'))
+        self.assertEqual(decimal_price, decimal.Decimal('11.33'))
 
     def test_parse_price_without_space(self):
         price = '21,37zł'
@@ -46,7 +46,7 @@ class TestUtils(TestCase):
     def test_parse_price_without_decimal_separator(self):
         price = '2137 CZK'
         decimal_price = utils.parse_price(price)
-        self.assertEquals(decimal_price, decimal.Decimal('2137'))
+        self.assertEqual(decimal_price, decimal.Decimal('2137'))
 
     def test_get_key_value_from_url(self):
         url = 'https://steamcommunity.com/tradeoffer/new/?partner=aaa&token=bbb'


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .