### PR TITLE
Created economy methods with tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Table of Content
 
 * [SteamChat methods](https://github.com/bukson/steampy#steamchat-methods)
 
+* [Utils methods](https://github.com/bukson/steampy#utils-methods)
+
 * [Test](https://github.com/bukson/steampy#test)
 
 * [License](https://github.com/bukson/steampy#license)
@@ -596,6 +598,43 @@ Returns a dictionary with all new sent and received messages:
 ```
 
 `client.chat.fetch_messages()`
+
+Utils methods
+======================
+
+**calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
+
+Calculate the price including the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum 
+fee of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by 
+Steam in the future.
+
+Returns the amount that the buyer pays during a market transaction:
+
+```python
+from decimal import Decimal
+from steampy.utils import calculate_gross_price
+
+publisher_fee = Decimal('0.1')  # 10%
+
+calculate_gross_price(Decimal('100'), publisher_fee)     # returns Decimal('115')
+```
+
+**calculate_net_price(price_gross: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
+
+Calculate the price without the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum fee 
+of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by Steam 
+in the future.
+
+Returns the amount that the seller receives after a market transaction:
+
+```python
+from decimal import Decimal
+from steampy.utils import calculate_net_price
+
+publisher_fee = Decimal('0.1')  # 10%
+
+calculate_net_price(Decimal('115'), publisher_fee)     # returns Decimal('100')
+```
 
 Test
 ====

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Returns a dictionary with all new sent and received messages:
 Utils methods
 ======================
 
-**calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
+**calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:**
 
 Calculate the price including the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum 
 fee of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by 
@@ -619,7 +619,7 @@ publisher_fee = Decimal('0.1')  # 10%
 calculate_gross_price(Decimal('100'), publisher_fee)     # returns Decimal('115')
 ```
 
-**calculate_net_price(price_gross: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
+**calculate_net_price(price_gross: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:**
 
 Calculate the price without the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum fee 
 of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by Steam 

--- a/steampy/utils.py
+++ b/steampy/utils.py
@@ -1,14 +1,13 @@
-import decimal
 import os
-
+import re
 import copy
 import struct
-import urllib.parse as urlparse
-import re
-from requests.structures import CaseInsensitiveDict
 from typing import List
+from decimal import Decimal
+from urllib.parse import urlparse, parse_qs
 
 from bs4 import BeautifulSoup, Tag
+from requests.structures import CaseInsensitiveDict
 
 from steampy.models import GameOptions
 
@@ -40,11 +39,11 @@ def steam_id_to_account_id(steam_id: str) -> str:
     return str(struct.unpack('>L', int(steam_id).to_bytes(8, byteorder='big')[4:])[0])
 
 
-def parse_price(price: str) -> decimal.Decimal:
+def parse_price(price: str) -> Decimal:
     pattern = '\D?(\\d*)(\\.|,)?(\\d*)'
     tokens = re.search(pattern, price, re.UNICODE)
     decimal_str = tokens.group(1) + '.' + tokens.group(3)
-    return decimal.Decimal(decimal_str)
+    return Decimal(decimal_str)
 
 
 def merge_items_with_descriptions_from_inventory(inventory_response: dict, game: GameOptions) -> dict:
@@ -74,8 +73,7 @@ def merge_items_with_descriptions_from_offer(offer: dict, descriptions: dict) ->
     return offer
 
 
-def merge_items_with_descriptions_from_listing(listings: dict, ids_to_assets_address: dict,
-                                               descriptions: dict) -> dict:
+def merge_items_with_descriptions_from_listing(listings: dict, ids_to_assets_address: dict, descriptions: dict) -> dict:
     for listing_id, listing in listings.get("sell_listings").items():
         asset_address = ids_to_assets_address[listing_id]
         description = descriptions[asset_address[0]][asset_address[1]][asset_address[2]]
@@ -163,12 +161,12 @@ def get_description_key(item: dict) -> str:
     return item['classid'] + '_' + item['instanceid']
 
 
-def get_key_value_from_url(url: str, key: str, case_sensitive: bool=True) -> str:
-    params = urlparse.urlparse(url).query
+def get_key_value_from_url(url: str, key: str, case_sensitive: bool = True) -> str:
+    params = urlparse(url).query
     if case_sensitive:
-        return urlparse.parse_qs(params)[key][0]
+        return parse_qs(params)[key][0]
     else:
-        return CaseInsensitiveDict(urlparse.parse_qs(params))[key][0]
+        return CaseInsensitiveDict(parse_qs(params))[key][0]
 
 
 def load_credentials():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -57,3 +57,19 @@ class TestUtils(TestCase):
         url = 'https://steamcommunity.com/tradeoffer/new/?Partner=aaa&Token=bbb'
         self.assertEqual(utils.get_key_value_from_url(url, 'partner', case_sensitive=False), 'aaa')
         self.assertEqual(utils.get_key_value_from_url(url, 'token', case_sensitive=False), 'bbb')
+
+    def test_calculate_gross_price(self):
+        steam_fee = Decimal('0.05')  # 5%
+        publisher_fee = Decimal('0.1')  # 10%
+
+        self.assertEqual(utils.calculate_gross_price(Decimal('0.01'), publisher_fee, steam_fee), Decimal('0.03'))
+        self.assertEqual(utils.calculate_gross_price(Decimal('0.10'), publisher_fee, steam_fee), Decimal('0.12'))
+        self.assertEqual(utils.calculate_gross_price(Decimal('100'), publisher_fee, steam_fee), Decimal('115'))
+
+    def test_calculate_net_price(self):
+        steam_fee = Decimal('0.05')     # 5%
+        publisher_fee = Decimal('0.1')      # 10%
+
+        self.assertEqual(utils.calculate_net_price(Decimal('0.03'), publisher_fee, steam_fee), Decimal('0.01'))
+        self.assertEqual(utils.calculate_net_price(Decimal('0.12'), publisher_fee, steam_fee), Decimal('0.10'))
+        self.assertEqual(utils.calculate_net_price(Decimal('115'), publisher_fee, steam_fee), Decimal('100'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,4 @@
-import decimal
+from decimal import Decimal
 from unittest import TestCase
 
 from steampy import utils
@@ -10,7 +10,7 @@ class TestUtils(TestCase):
         text = 'var a = "dupadupa";'
         text_between = utils.text_between(text, 'var a = "', '";')
         self.assertEqual(text_between, 'dupadupa')
-        
+
     def test_texts_between(self):
         text = "<li>element 1</li>\n<li>some random element</li>"
         items = []
@@ -31,22 +31,22 @@ class TestUtils(TestCase):
     def test_parse_price_with_currency_symbol(self):
         price = '$11.33 USD'
         decimal_price = utils.parse_price(price)
-        self.assertEqual(decimal_price, decimal.Decimal('11.33'))
+        self.assertEqual(decimal_price, Decimal('11.33'))
 
     def test_parse_price_without_currency_symbol(self):
         price = '11,33 USD'
         decimal_price = utils.parse_price(price)
-        self.assertEqual(decimal_price, decimal.Decimal('11.33'))
+        self.assertEqual(decimal_price, Decimal('11.33'))
 
     def test_parse_price_without_space(self):
         price = '21,37zł'
         decimal_price = utils.parse_price(price)
-        self.assertEqual(decimal_price, decimal.Decimal('21.37'))
+        self.assertEqual(decimal_price, Decimal('21.37'))
 
     def test_parse_price_without_decimal_separator(self):
         price = '2137 CZK'
         decimal_price = utils.parse_price(price)
-        self.assertEqual(decimal_price, decimal.Decimal('2137'))
+        self.assertEqual(decimal_price, Decimal('2137'))
 
     def test_get_key_value_from_url(self):
         url = 'https://steamcommunity.com/tradeoffer/new/?partner=aaa&token=bbb'


### PR DESCRIPTION
Based on the Javascript code from `https://community.cloudflare.steamstatic.com/public/javascript/economy_common.js` (`CalculateFeeAmount` and `CalculateAmountToSendForDesiredReceivedAmount` functions) that is used by Steam when a user sells an item from his inventory, i've implemented the same algorithm using Python. 
Here is a list of what has been done:

- Optimized imports
- Created calculation methods (net to gross, gross to net)
- Created docstring
- Created documentation in README
- Added unit tests

All tests are passed:
``` sh
~/steampy/test# python -m unittest test_utils.py --verbose

test_account_id_to_steam_id (test_utils.TestUtils.test_account_id_to_steam_id) ... ok
test_calculate_gross_price (test_utils.TestUtils.test_calculate_gross_price) ... ok
test_calculate_net_price (test_utils.TestUtils.test_calculate_net_price) ... ok
test_get_key_value_from_url (test_utils.TestUtils.test_get_key_value_from_url) ... ok
test_get_key_value_from_url_case_insensitive (test_utils.TestUtils.test_get_key_value_from_url_case_insensitive) ... ok
test_parse_price_with_currency_symbol (test_utils.TestUtils.test_parse_price_with_currency_symbol) ... ok
test_parse_price_without_currency_symbol (test_utils.TestUtils.test_parse_price_without_currency_symbol) ... ok
test_parse_price_without_decimal_separator (test_utils.TestUtils.test_parse_price_without_decimal_separator) ... ok
test_parse_price_without_space (test_utils.TestUtils.test_parse_price_without_space) ... ok
test_steam_id_to_account_id (test_utils.TestUtils.test_steam_id_to_account_id) ... ok
test_text_between (test_utils.TestUtils.test_text_between) ... ok
test_texts_between (test_utils.TestUtils.test_texts_between) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.001s

OK
```
