### PR TITLE
Fixed "steamid" parsing as an integer

### DIFF
--- a/steampy/guard.py
+++ b/steampy/guard.py
@@ -1,10 +1,9 @@
-import base64
+import os
 import hmac
 import json
 import struct
-import time
-import os
-
+from time import time
+from base64 import b64encode, b64decode
 from hashlib import sha1
 
 
@@ -18,9 +17,9 @@ def load_steam_guard(steam_guard: str) -> dict:
 
 def generate_one_time_code(shared_secret: str, timestamp: int = None) -> str:
     if timestamp is None:
-        timestamp = int(time.time())
+        timestamp = int(time())
     time_buffer = struct.pack('>Q', timestamp // 30)  # pack as Big endian, uint64
-    time_hmac = hmac.new(base64.b64decode(shared_secret), time_buffer, digestmod=sha1).digest()
+    time_hmac = hmac.new(b64decode(shared_secret), time_buffer, digestmod=sha1).digest()
     begin = ord(time_hmac[19:20]) & 0xf
     full_code = struct.unpack('>I', time_hmac[begin:begin + 4])[0] & 0x7fffffff  # unpack as Big endian uint32
     chars = '23456789BCDFGHJKMNPQRTVWXY'
@@ -33,9 +32,9 @@ def generate_one_time_code(shared_secret: str, timestamp: int = None) -> str:
     return code
 
 
-def generate_confirmation_key(identity_secret: str, tag: str, timestamp: int = int(time.time())) -> bytes:
+def generate_confirmation_key(identity_secret: str, tag: str, timestamp: int = int(time())) -> bytes:
     buffer = struct.pack('>Q', timestamp) + tag.encode('ascii')
-    return base64.b64encode(hmac.new(base64.b64decode(identity_secret), buffer, digestmod=sha1).digest())
+    return b64encode(hmac.new(b64decode(identity_secret), buffer, digestmod=sha1).digest())
 
 
 # It works, however it's different that one generated from mobile app

--- a/steampy/guard.py
+++ b/steampy/guard.py
@@ -3,16 +3,25 @@ import hmac
 import json
 import struct
 from time import time
+from typing import Dict
 from base64 import b64encode, b64decode
 from hashlib import sha1
 
 
-def load_steam_guard(steam_guard: str) -> dict:
+def load_steam_guard(steam_guard: str) -> Dict[str, str]:
+    """Load Steam Guard credentials from json (file or string).
+
+    Arguments:
+        steam_guard (str): If this string is a path to a file, then its contents will be parsed as a json data.
+            Otherwise, the string will be parsed as a json data.
+    Returns:
+        Dict[str, str]: Parsed json data as a dictionary of strings (both key and value).
+    """
     if os.path.isfile(steam_guard):
         with open(steam_guard, 'r') as f:
-            return json.loads(f.read())
+            return json.loads(f.read(), parse_int=str)
     else:
-        return json.loads(steam_guard)
+        return json.loads(steam_guard, parse_int=str)
 
 
 def generate_one_time_code(shared_secret: str, timestamp: int = None) -> str:

--- a/test/test_guard.py
+++ b/test/test_guard.py
@@ -1,4 +1,4 @@
-import base64
+from base64 import b64encode
 from unittest import TestCase
 
 from steampy import guard
@@ -9,8 +9,8 @@ class TestGuard(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.shared_secret = base64.b64encode('1234567890abcdefghij'.encode('utf-8'))
-        cls.identity_secret = base64.b64encode('abcdefghijklmnoprstu'.encode('utf-8'))
+        cls.shared_secret = b64encode('1234567890abcdefghij'.encode('utf-8'))
+        cls.identity_secret = b64encode('abcdefghijklmnoprstu'.encode('utf-8'))
 
     def test_one_time_code(self):
         timestamp = 1469184207
@@ -26,3 +26,13 @@ class TestGuard(TestCase):
         steam_id = "12341234123412345"
         device_id = guard.generate_device_id(steam_id)
         self.assertEqual(device_id, "android:677cf5aa-3300-7807-d1e2-c408142742e2")
+
+    def test_load_steam_guard(self):
+        expected_keys = ("steamid", "shared_secret", "identity_secret")
+
+        guard_json_str = '{"steamid": 12345678, "shared_secret": "SHARED_SECRET", "identity_secret": "IDENTITY_SECRET"}'
+        guard_data = guard.load_steam_guard(guard_json_str)
+
+        for key in expected_keys:
+            self.assertIn(key, guard_data)
+            self.assertIsInstance(guard_data[key], str)


### PR DESCRIPTION
While using the `steampy`, the value if `steamid` is expected to be of a string type, but it can be parsed as an integer. Specifying json data incorrectly can cause undefined behavior in future use.

Changed:
- Optimized imports
- Added more specific return type
- Added docstring
- JSON `int` loads as a string
- Created unit test

Tests results:
```sh
~/steampy/test# python -m unittest test_guard.py --verbose
test_confirmation_key (test_guard.TestGuard.test_confirmation_key) ... ok
test_generate_device_id (test_guard.TestGuard.test_generate_device_id) ... ok
test_load_steam_guard (test_guard.TestGuard.test_load_steam_guard) ... ok
test_one_time_code (test_guard.TestGuard.test_one_time_code) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.001s

OK
```