### PR TITLE
fix get_steam_id()

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -57,7 +57,7 @@ class SteamClient:
     def get_steam_id(self) -> int:
         url = SteamUrl.COMMUNITY_URL
         response = self._session.get(url)
-        steam_id = re.match(r'g_steamID = "(\d+)";', response.text)
+        steam_id = re.search(r'g_steamID = "(\d+)";', response.text)
         if steam_id:
             return int(steam_id.group(1))
         else:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -17,6 +17,11 @@ class TestSteamClient(TestCase):
         dirname = os.path.dirname(os.path.abspath(__file__))
         cls.steam_guard_file = dirname + '/../secrets/Steamguard.txt'
 
+    def test_get_steam_id(self):
+        client = SteamClient(self.credentials.api_key)
+        client.login(self.credentials.login, self.credentials.password, self.steam_guard_file)
+        self.assertTrue(client.get_steam_id() == int(self.steam_guard_file["Session"]["SteamID"]))
+
     def test_login(self):
         client = SteamClient(self.credentials.api_key)
         client.login(self.credentials.login, self.credentials.password, self.steam_guard_file)


### PR DESCRIPTION
## Test case:
```python
import re

# fixed
def search_get_steam_id() -> int:
    text = '    g_steamID = "76561198085278322";'
    steam_id = re.search(r'g_steamID = "(\d+)";', text)
    if steam_id:
        return int(steam_id.group(1))
    else:
        raise ValueError('Invalid steam_id: {}'.format(steam_id))

# not fixed
def match_get_steam_id() -> int:
    text = '    g_steamID = "76561198085278322";'
    steam_id = re.match(r'g_steamID = "(\d+)";', text)
    if steam_id:
        return int(steam_id.group(1))
    else:
        raise ValueError('Invalid steam_id: {}'.format(steam_id))

print(search_get_steam_id())
# 76561198085278322
print(match_get_steam_id())
# ValueError: Invalid steam_id: None
```