### PR TITLE
fix steam_guard passing and case login after passing login_cookies

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -64,9 +64,6 @@ class SteamClient:
             raise ValueError('Invalid steam_id: {}'.format(steam_id))
 
     def login(self, username: str = None, password: str = None, steam_guard: str = None) -> None:
-        if self.was_login_executed and self.is_session_alive():
-            # session is alive, no need login again
-            return
 
         if None in [self.username, self._password, self.steam_guard_string] and None in [username, password, steam_guard]:
             raise InvalidCredentials('You have to pass username, password and steam_guard'
@@ -77,6 +74,11 @@ class SteamClient:
             self.steam_guard = guard.load_steam_guard(steam_guard)
             self.username = username
             self._password = password
+            
+        if self.was_login_executed and self.is_session_alive():
+            # session is alive, no need login again
+            return
+        
         self._session.cookies.set("steamRememberLogin", 'true')
         LoginExecutor(self.username, self._password, self.steam_guard['shared_secret'], self._session).login()
         self.was_login_executed = True

--- a/steampy/client.py
+++ b/steampy/client.py
@@ -27,7 +27,7 @@ class SteamClient:
             self.set_proxies(proxies)
         self.steam_guard_string = steam_guard
         if self.steam_guard_string is not None:
-            self.steam_guard = guard.load_steam_guard(self.steam_guard)
+            self.steam_guard = guard.load_steam_guard(self.steam_guard_string)
         else:
             self.steam_guard = None
         self.was_login_executed = False
@@ -71,10 +71,10 @@ class SteamClient:
 
         if None in [self.username, self._password, self.steam_guard_string]:
             self.steam_guard_string = steam_guard
-            self.steam_guard = guard.load_steam_guard(steam_guard)
+            self.steam_guard = guard.load_steam_guard(self.steam_guard_string)
             self.username = username
             self._password = password
-            
+
         if self.was_login_executed and self.is_session_alive():
             # session is alive, no need login again
             return


### PR DESCRIPTION
# `login()` after passing `login_cookies`
## Error case:
```python
steam_client = SteamClient("API_KEY", login_cookies = cookies)
steam_client.login("USERNAME", "PASSWORD", "guard.json")    
if steam_client.is_session_alive():
    print('ok')
```
raise in `.login()` func
```
...steampy\client.py", line 105, in is_session_alive
    return steam_login.lower() in main_page_response.text.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```
because `username` not saved and `steam_login` still `None`
### Note
also `is_session_alive` may check is `self.username` not `None`
or add func `get_username()` for get account login

---
# passing `steam_guard` in `__init__()` function
## Error case:
```python
steam_client = SteamClient("API_KEY", "USERNAME", steam_guard = "guard.json", login_cookies = cookies)
```
raise
```
...steampy\client.py", line 30, in __init__
    self.steam_guard = guard.load_steam_guard(self.steam_guard)
AttributeError: 'SteamClient' object has no attribute 'steam_guard'
```
because `guard.load_steam_guard()` should take `self.steam_guard_string` as arg, not `self.steam_guard`.
