### PR TITLE
Update utils.py

### DIFF
--- a/steampy/utils.py
+++ b/steampy/utils.py
@@ -54,6 +54,7 @@ def steam_id_to_account_id(steam_id: str) -> str:
 
 
 def parse_price(price: str) -> Decimal:
+    price = price.replace(' ', '')
     pattern = '\D?(\\d*)(\\.|,)?(\\d*)'
     tokens = re.search(pattern, price, re.UNICODE)
     decimal_str = tokens.group(1) + '.' + tokens.group(3)


### PR DESCRIPTION
Currently, if you are using **get_wallet_balance()** method it will return incorrect balance value. It parses first numbers before the space and return them. It can be fixed by simply adding a space removal to the "**parse_price()**" function.

**Example**: 

User have actual balance value as "15 234,15₴" it returns balance value as "15" instead of "15 234.15".

```python
# FIXED FUNCTION
def parse_price(price: str) -> Decimal:
    price = price.replace(' ', '')  # <- Added space removal
    pattern = '\D?(\\d*)(\\.|,)?(\\d*)'
    tokens = re.search(pattern, price, re.UNICODE)
    decimal_str = tokens.group(1) + '.' + tokens.group(3)
    return Decimal(decimal_str)
```
**Output**:
`15 234.15`

```python
# PREVIOUS ONE
def parse_price(price: str) -> Decimal:
    pattern = '\D?(\\d*)(\\.|,)?(\\d*)'
    tokens = re.search(pattern, price, re.UNICODE)
    decimal_str = tokens.group(1) + '.' + tokens.group(3)
    return Decimal(decimal_str)
```
**Output**:
`15`