### PR TITLE
Add new Pull Request workflow

### DIFF
--- a/.github/workflows/pythonpr.yml
+++ b/.github/workflows/pythonpr.yml
@@ -1,0 +1,26 @@
+name: ci-python-unittest
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Unit tests
+        run: |
+          pip install .
+          python -m unittest discover -s ./test  -p 'test_*.py'

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,19 +8,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,13 +1,14 @@
 import os
 from decimal import Decimal
 from unittest import TestCase
+import unittest
 
 from steampy.client import SteamClient
 from steampy.exceptions import LoginRequired
 from steampy.models import GameOptions, Asset
 from steampy.utils import account_id_to_steam_id, load_credentials
 
-
+@unittest.skip('Requires secrets/Steamguard.txt')
 class TestSteamClient(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/test_market.py
+++ b/test/test_market.py
@@ -1,12 +1,13 @@
 import os
 from unittest import TestCase
+import unittest
 
 from steampy.client import SteamClient
 from steampy.exceptions import TooManyRequests
 from steampy.models import GameOptions, Currency
 from steampy.utils import load_credentials
 
-
+@unittest.skip('Requires secrets/Steamguard.txt')
 class TestMarket(TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
I added a few changes:

- A new GitHub action workflow for Pull Requests was made. It will build the project and execute the unit tests (currently 12 tests of 38).
- Skipped the tests that use a secret (Steam Guard).
- Added a matrix to validate in the future more Python versions (currently only 3.8, but in the future, we can check 3.9, 3.10, ...).
- Updated to the latest version of "checkout" and "setup-python" to use a newer node.

I created a test PR to validate this workflow (https://github.com/AlberTajuelo/steampy/pull/3).
