### PR TITLE
feature: add pydoctor to generate automatic documentation

### DIFF
--- a/.github/workflows/ci-python-apidocs.yml
+++ b/.github/workflows/ci-python-apidocs.yml
@@ -1,0 +1,42 @@
+name: ci-python-apidocs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  ci-python-apidocs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install requirements for documentation generation
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install docutils pydoctor
+
+      - name: Generate API documentation with pydoctor
+        run: |
+          pydoctor \
+              --project-name=steampy \
+              --project-url=https://github.com/$GITHUB_REPOSITORY \
+              --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA \
+              --make-html \
+              --html-output=./apidocs \
+              --project-base-dir="$(pwd)" \
+              --docformat=restructuredtext \
+              --intersphinx=https://docs.python.org/3/objects.inv \
+              ./steampy
+
+      - name: Push API documentation to Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apidocs
+          commit_message: "Generate API documentation"

--- a/.github/workflows/ci-python-unittest.yml
+++ b/.github/workflows/ci-python-unittest.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 jobs:
-  unittest:
+  ci-python-unittest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,4 +23,4 @@ jobs:
       - name: Unit tests
         run: |
           pip install .
-          python -m unittest discover -s ./test  -p 'test_*.py'
+          python -m unittest discover -s ./test -p 'test_*.py'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,13 @@
-Please make all pull request with 1 commit that can be easily rebased onto master.
+Contributions are the heartbeat of the open source community, transforming it into a vibrant space for learning, inspiring, and creating. Every contribution you bring adds immense value and is genuinely appreciated.
 
-Please add tests for new functions.
+If you have a suggestion to enhance the project, we encourage you to fork the repository and initiate a pull request. Alternatively, you can effortlessly open an issue, labeling it as "enhancement." And hey, don't forget to show your support by giving the project a star! Your efforts make a significant difference - thank you!
+
+Here's a quick guide to getting involved:
+
+- Fork the Project
+- Create your Feature Branch (git checkout -b feature/AmazingFeature)
+- Commit your Changes (git commit -m 'Add some AmazingFeature'). Make sure all pull requests contains only _1 commit_ that can be easily rebased onto master branch. Add tests for new functions.
+- Push to the Branch (git push origin feature/AmazingFeature)
+- Open a Pull Request
+
+Your contributions are the driving force behind the project's growth, and we're excited to collaborate with you!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Michał Bukowski gigibukson@gmail.com
+Copyright (c) 2023 Michał Bukowski gigibukson@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,58 +1,52 @@
-Steam Trade Offers Client for Python
-=======
+# Steam Trade Offers Client for Python
 
 [![PayPal Donate Button](https://img.shields.io/badge/donate-paypal-orange.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XC8BMJ8QRD9ZY "Donate to this project via PayPal")
 
-Donate bitcoin: 3PRzESHsTVkCFK7osjwFGQLZjSf7qXP1Ta 
+Donate bitcoin: 3PRzESHsTVkCFK7osjwFGQLZjSf7qXP1Ta
 
 `steampy` is a library for Python, inspired by node-steam-tradeoffers, node-steam and other libraries for Node.js.
 It was designed as a simple lightweight library, combining features of many steam libraries from Node.js into a single python module.
 `steampy` is capable of logging into steam, fetching trade offers and handling them in simple manner, using steam user credentials
-and SteamGuard file, or by passing sessionID and webCookie cookies. 
+and SteamGuard file, or by passing sessionID and webCookie cookies.
 'steampy' is also capable of using proxies.
 `steampy` is developed with Python 3 using type hints and many other features its supported for Windows, Linux and MacOs.
 
-Table of Content
-================
+# Table of Content
 
-* [Installation](https://github.com/bukson/steampy#installation)
+- [Installation](https://github.com/bukson/steampy#installation)
 
-* [Usage](https://github.com/bukson/steampy#usage)
+- [Usage](https://github.com/bukson/steampy#usage)
 
-* [Examples](https://github.com/bukson/steampy#examples)
+- [Examples](https://github.com/bukson/steampy#examples)
 
-* [SteamClient methods](https://github.com/bukson/steampy#steamclient-methods)
+- [SteamClient methods](https://github.com/bukson/steampy#steamclient-methods)
 
-* [Market methods](https://github.com/bukson/steampy#market-methods)
+- [Market methods](https://github.com/bukson/steampy#market-methods)
 
-* [Guard module functions](https://github.com/bukson/steampy#guard-module-functions)
+- [Guard module functions](https://github.com/bukson/steampy#guard-module-functions)
 
-* [Utils methods](https://github.com/bukson/steampy#utils-methods)
+- [Utils methods](https://github.com/bukson/steampy#utils-methods)
 
-* [Test](https://github.com/bukson/steampy#test)
+- [Test](https://github.com/bukson/steampy#test)
 
-* [License](https://github.com/bukson/steampy#license)
+# Installation
 
+Requires Python 3.8 at least.
 
-Installation
-============
-
-Requires python 3.8 at least
 ```
 pip install steampy
 ```
 
-Usage
-=======
+# Usage
+
 [Obtaining API Key](http://steamcommunity.com/dev/apikey)
 
-[Obtaining SteamGuard from mobile device]( https://github.com/SteamTimeIdler/stidler/wiki/Getting-your-%27shared_secret%27-code-for-use-with-Auto-Restarter-on-Mobile-Authentication )
+[Obtaining SteamGuard from mobile device](https://github.com/SteamTimeIdler/stidler/wiki/Getting-your-%27shared_secret%27-code-for-use-with-Auto-Restarter-on-Mobile-Authentication)
 
-[Obtaining SteamGuard using Android emulation]( https://github.com/codepath/android_guides/wiki/Genymotion-2.0-Emulators-with-Google-Play-support)
+[Obtaining SteamGuard using Android emulation](https://github.com/codepath/android_guides/wiki/Genymotion-2.0-Emulators-with-Google-Play-support)
 
-** __init__(self, api_key: str, username: str = None, password: str = None, steam_guard: str = None,
-                 login_cookies: dict = None, proxies: dict = None) -> None:**
-
+\*\* **init**(self, api_key: str, username: str = None, password: str = None, steam_guard: str = None,
+login_cookies: dict = None, proxies: dict = None) -> None:\*\*
 
 SteamClient needs at least api_key to provide some functionalities. User can also provide username, password
 and SteamGuard file to be able to log in and use more methods. Proxies are also supported.
@@ -80,7 +74,7 @@ assert steam_client.was_login_executed
 from steampy.client import SteamClient
 
 proxies =  {
-    "http": "http://login:password@host:port", 
+    "http": "http://login:password@host:port",
     "https": "http://login:password@host:port"
 }
 
@@ -88,9 +82,8 @@ steam_client = SteamClient('MY_API_KEY', proxies=proxies)
 
 ```
 
-
-
 If you have `steamid`, `shared_secret` and `identity_secret` you can place it in file `Steamguard.txt` instead of fetching SteamGuard file from device.
+
 ```python
 {
     "steamid": "YOUR_STEAM_ID_64",
@@ -99,10 +92,9 @@ If you have `steamid`, `shared_secret` and `identity_secret` you can place it in
 }
 ```
 
-Examples
-========
+# Examples
 
-You'll need to obtain your API key and SteamGuard file in order to run the examples, 
+You'll need to obtain your API key and SteamGuard file in order to run the examples,
 and then fill login and password in `storehose.py` file.
 The `storehouse.py` file contains an example of handling incoming trade offers.
 
@@ -112,28 +104,26 @@ python storehouse.py
 
 If you want to generate authentication codes and use steampy as steam desktop authenticator
 then fill required secrets in `desktop_authenticator.py` file.
-The `desktop_authenticator.py` file contains examples of generating such one time codes/
+The `desktop_authenticator.py` file contains examples of generating such one time codes.
 
 ```
 python desktop_authenticator.py
 ```
 
+# SteamClient methods
 
-SteamClient methods
-===================
-
-Unless specified in documentation, the method does not require login to work(it uses API Key from constructor instead)
+Unless specified in documentation, the method does not require login to work (it uses API Key from constructor instead).
 
 **def set_proxy(self, proxy: dict) -> dict**
 
-Set proxy for steampy session, example: 
+Set proxy for steampy session, example:
 
 ```python
 from steampy.client import SteamClient
 
 steam_client = SteamClient('MY_API_KEY')
 proxies =  {
-    "http": "http://login:password@host:port", 
+    "http": "http://login:password@host:port",
     "https": "http://login:password@host:port"
 }
 steam_client.set_proxies(proxies)
@@ -227,8 +217,8 @@ steam_client = SteamClient('MY_API_KEY')
 params = {'key': 'MY_API_KEY'}
 summaries =  steam_client.api_call('GET', 'IEconService', 'GetTradeOffersSummary', 'v1', params).json()
 ```
-**get_trade_offers_summary() -> dict**
 
+**get_trade_offers_summary() -> dict**
 
 **get_trade_offers(merge: bool = True) -> dict**
 
@@ -245,14 +235,12 @@ and descriptions merged with data are value.
 
 **get_trade_offer(trade_offer_id: str, merge: bool = True) -> dict**
 
-
 **get_trade_receipt(trade_id: str) -> list**
 
 Using `SteamClient.login` method is required before usage
 Getting the receipt for a trade with all item information after the items has been traded.
 Do NOT store any item ids before you got the receipt since the ids may change.
 "trade_id" can be found in trade offers: `offer['response']['offer']['tradeid']`. Do not use ´tradeofferid´.
-
 
 **make_offer(items_from_me: List[Asset], items_from_them: List[Asset], partner_steam_id: str, message:str ='') -> dict**
 
@@ -442,14 +430,15 @@ Inventory items can be merged like in `SteamClient.get_my_inventory` method
 
 **get_wallet_balance(convert_to_decimal: bool = True, on_hold: bool = False) -> Union[str, float]**
 
-Check account balance of steam acccount. It converts money string to Decimal if `convert_to_decimal` is set to `True`, 
+Check account balance of steam acccount. It converts money string to Decimal if `convert_to_decimal` is set to `True`,
 otherwise, it will return the value string without a decimal point.
 If the `on_hold` parameter is set to `True`, it will return the current on-hold balance value.
 
 Example:
+
 ```python
 from steampy.client import SteamClient
-from decimal import Decimal 
+from decimal import Decimal
 with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD_FILE') as client:
             wallet_balance = client.get_wallet_balance()
             on_hold_wallet_balance = client.get_wallet_balance(on_hold = True)
@@ -457,8 +446,7 @@ with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD
             assert type(on_hold_wallet_balance) == Decimal
 ```
 
-market methods
-==============
+# market methods
 
 **fetch_price(item_hash_name: str, game: GameOptions, currency: str = Currency.USD) -> dict**
 
@@ -486,6 +474,7 @@ price = steam_client.market.fetch_price(item, game=GameOptions.CS)
 Using `SteamClient.login` method is required before usage
 
 Returns list of price history of and item.
+
 ```python
 from steampy.client import SteamClient
 from steampy.models import GameOptions
@@ -512,7 +501,6 @@ with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD
     listings = client.market.get_my_market_listings()
 ```
 
-
 **create_sell_order(assetid: str, game: GameOptions, money_to_receive: str) -> dict**
 
 Using `SteamClient.login` method is required before usage
@@ -528,7 +516,7 @@ with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD
     game = GameOptions.DOTA2
     sell_response = client.market.create_sell_order(asset_id_to_sell, game, "10000")
 ```
- 
+
 ⚠️ `money_to_receive` has to be in cents, so "100.00" should be passed has "10000"
 
 **create_buy_order(market_name: str, price_single_item: str, quantity: int, game: GameOptions, currency: Currency = Currency.USD) -> dict**
@@ -545,6 +533,7 @@ with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD
     response = client.market.create_buy_order("AK-47 | Redline (Field-Tested)", "1034", 2, GameOptions.CS, Currency.EURO)
     buy_order_id = response["buy_orderid"]
 ```
+
 ⚠️ `price_single_item` has to be in cents, so "10.34" should be passed has "1034"
 
 **buy_item(market_name: str, market_id: str, price: int, fee: int, game: GameOptions, currency: Currency = Currency.USD) -> dict**
@@ -591,61 +580,11 @@ with SteamClient('MY_API_KEY', 'MY_USERNAME', 'MY_PASSWORD', 'PATH_TO_STEAMGUARD
     response = client.market.cancel_buy_order(buy_order_id)
 ```
 
-Currencies
-----------
+## Currencies
 
-| Currency class | Description                 |
-| ---            | ---                         |
-| Currency.USD   | United States Dollar        |
-| Currency.GBP   | United Kingdom Pound        |
-| Currency.EURO  | European Union Euro         |
-| Currency.CHF   | Swiss Francs                |
-| Currency.RUB   | Russian Rouble              |
-| Currency.PLN   | Polish Złoty                |
-| Currency.BRL   | Brazilian Reals             |
-| Currency.JPY   | Japanese Yen                |
-| Currency.NOK   | Norwegian Krone             |
-| Currency.IDR   | Indonesian Rupiah           |
-| Currency.MYR   | Malaysian Ringgit           |
-| Currency.PHP   | Philippine Peso             |
-| Currency.SGD   | Singapore Dollar            |
-| Currency.THB   | Thai Baht                   |
-| Currency.VND   | Vietnamese Dong             |
-| Currency.KRW   | South Korean Won            |
-| Currency.TRY   | Turkish Lira                |
-| Currency.UAH   | Ukrainian Hryvnia           |
-| Currency.MXN   | Mexican Peso                |
-| Currency.CAD   | Canadian Dollars            |
-| Currency.AUD   | Australian Dollars          |
-| Currency.NZD   | New Zealand Dollar          |
-| Currency.CNY   | Chinese Renminbi (yuan)     |
-| Currency.INR   | Indian Rupee                |
-| Currency.CLP   | Chilean Peso                |
-| Currency.PEN   | Peruvian Sol                |
-| Currency.COP   | Colombian Peso              |
-| Currency.ZAR   | South African Rand          |
-| Currency.HKD   | Hong Kong Dollar            |
-| Currency.TWD   | New Taiwan Dollar           |
-| Currency.SAR   | Saudi Riyal                 |
-| Currency.AED   | United Arab Emirates Dirham |
-| Currency.SEK   | Swedish Krona               |
-| Currency.ARS   | Argentine Peso              |
-| Currency.ILS   | Israeli New Shekel          |
-| Currency.BYN   | Belarusian Ruble            |
-| Currency.KZT   | Kazakhstani Tenge           |
-| Currency.KWD   | Kuwaiti Dinar               |
-| Currency.QAR   | Qatari Riyal                |
-| Currency.CRC   | Costa Rican Colón           |
-| Currency.UYU   | Uruguayan Peso              |
-| Currency.BGN   | Bulgarian Lev               |
-| Currency.HRK   | Croatian Kuna               |
-| Currency.CZK   | Czech Koruna                |
-| Currency.DKK   | Danish Krone                |
-| Currency.HUF   | Hungarian Forint            |
-| Currency.RON   | Romanian Leu                |
+All currencies are listed in [this page](https://bukson.github.io/steampy/steampy.models.Currency.html).
 
-guard module functions
-======================
+# guard module functions
 
 **load_steam_guard(steam_guard: str) -> dict**
 
@@ -658,17 +597,15 @@ If none timestamp provided, timestamp will be set to current time.
 
 **generate_confirmation_key(identity_secret: str, tag: str, timestamp: int = int(time.time())) -> bytes**
 
-Generate mobile device confirmation key for accepting trade offer. 
+Generate mobile device confirmation key for accepting trade offer.
 Default timestamp is current time.
 
-
-Utils methods
-======================
+# Utils methods
 
 **calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:**
 
-Calculate the price including the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum 
-fee of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by 
+Calculate the price including the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum
+fee of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by
 Steam in the future.
 
 Returns the amount that the buyer pays during a market transaction:
@@ -684,8 +621,8 @@ calculate_gross_price(Decimal('100'), publisher_fee)     # returns Decimal('115'
 
 **calculate_net_price(price_gross: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:**
 
-Calculate the price without the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum fee 
-of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by Steam 
+Calculate the price without the publisher's fee and the Steam fee. Most publishers have a `10%` fee with a minimum fee
+of `$0.01`. The Steam fee is currently `5%` (with a minimum fee of `$0.01`) and may be increased or decreased by Steam
 in the future.
 
 Returns the amount that the seller receives after a market transaction:
@@ -699,12 +636,11 @@ publisher_fee = Decimal('0.1')  # 10%
 calculate_net_price(Decimal('115'), publisher_fee)     # returns Decimal('100')
 ```
 
-Test
-====
+# Test
 
-All public methods are documented and tested. 
+All public methods are documented and tested.
 `guard` module has unit tests, `client` uses an acceptance test.
-For the acceptance test you have to put `credentials.pwd` and `Steamguard` file into `test` directory
+For the acceptance test you have to put `credentials.pwd` and `Steamguard` file into `test` directory.
 
 Example `credentials.pwd` file:
 
@@ -714,32 +650,7 @@ account2 password2 api_key2
 ```
 
 In some tests you also have to obtain `transaction_id`.
-You can do it by `SteamClient.get_trade_offers` or by logging manually into steam account in browser and get it from url
+You can do it by `SteamClient.get_trade_offers` or by logging manually into steam account in browser and get it from url.
 
 In some tests you also have to obtain partner steam id.
-You can do it by logging manually into steam account in browser and get it from url
-
-License
-=======
-
-MIT License
-
-Copyright (c) 2016 [Michał Bukowski](gigibukson@gmail.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You can do it by logging manually into steam account in browser and get it from url.

--- a/steampy/__init__.py
+++ b/steampy/__init__.py
@@ -1,0 +1,10 @@
+"""
+steampy is a library for Python, inspired by node-steam-tradeoffers, node-steam and other libraries for Node.js.
+It was designed as a simple lightweight library, combining features of many steam libraries from Node.js into a
+single python module. steampy is capable of logging into steam, fetching trade offers and handling them in simple
+manner, using steam user credentials and SteamGuard file, or by passing sessionID and webCookie cookies. 'steampy'
+is also capable of using proxies.
+
+steampy is developed with Python 3 using type hints and many other features its
+supported for Windows, Linux and MacOs.
+"""

--- a/steampy/client.py
+++ b/steampy/client.py
@@ -1,3 +1,6 @@
+"""
+Provides interactions with Steam
+"""
 import re
 import bs4
 import json

--- a/steampy/confirmation.py
+++ b/steampy/confirmation.py
@@ -1,3 +1,6 @@
+"""
+Provides Confirmation handler to deal with Steam request (mostly trade and sell)
+"""
 import enum
 import json
 import time

--- a/steampy/exceptions.py
+++ b/steampy/exceptions.py
@@ -1,3 +1,6 @@
+"""
+Provides exceptions handled in Steam
+"""
 class SevenDaysHoldException(Exception):
     pass
 

--- a/steampy/guard.py
+++ b/steampy/guard.py
@@ -1,3 +1,6 @@
+"""
+Provides Steam Guard functions
+"""
 import os
 import hmac
 import json

--- a/steampy/login.py
+++ b/steampy/login.py
@@ -1,3 +1,6 @@
+"""
+Provides Login in Steam functions
+"""
 from http import HTTPStatus
 from base64 import b64encode
 

--- a/steampy/market.py
+++ b/steampy/market.py
@@ -1,3 +1,6 @@
+"""
+Provides Steam Market functions
+"""
 import json
 import urllib.parse
 from decimal import Decimal

--- a/steampy/models.py
+++ b/steampy/models.py
@@ -1,3 +1,6 @@
+"""
+Provides models to interact with Steam API
+"""
 from enum import IntEnum
 from collections import namedtuple
 
@@ -33,67 +36,129 @@ class Asset:
 
 
 class Currency(IntEnum):
+    """
+    All currencies that are supported by Steam you can found them at https://partner.steamgames.com/doc/store/pricing/currencies
+    """
     USD = 1
+    """United States Dollar"""
     GBP = 2
+    """United Kingdom Pound"""
     EURO = 3
+    """European Union Euro"""
     CHF = 4
+    """Swiss Francs"""
     RUB = 5
+    """Russian Rouble"""
     PLN = 6
+    """Polish Złoty"""
     BRL = 7
+    """Brazilian Reals"""
     JPY = 8
+    """Japanese Yen"""
     NOK = 9
+    """Norwegian Krone"""
     IDR = 10
+    """Indonesian Rupiah"""
     MYR = 11
+    """Malaysian Ringgit"""
     PHP = 12
+    """Philippine Peso"""
     SGD = 13
+    """Singapore Dollar"""
     THB = 14
+    """Thai Baht"""
     VND = 15
+    """Vietnamese Dong"""
     KRW = 16
+    """South Korean Won"""
     TRY = 17
+    """	Turkish Lira"""
     UAH = 18
+    """Ukrainian Hryvnia"""
     MXN = 19
+    """Mexican Peso"""
     CAD = 20
+    """Canadian Dollars"""
     AUD = 21
+    """Australian Dollars"""
     NZD = 22
+    """New Zealand Dollar"""
     CNY = 23
+    """Chinese Renminbi (yuan)"""
     INR = 24
+    """Indian Rupee"""
     CLP = 25
+    """Chilean Peso"""
     PEN = 26
+    """Peruvian Sol"""
     COP = 27
+    """Colombian Peso"""
     ZAR = 28
+    """South African Rand"""
     HKD = 29
+    """Hong Kong Dollar"""
     TWD = 30
+    """New Taiwan Dollar"""
     SAR = 31
+    """Saudi Riyal"""
     AED = 32
+    """United Arab Emirates Dirham"""
     SEK = 33
+    """Swedish Krona"""
     ARS = 34
+    """Argentine Peso"""
     ILS = 35
+    """Israeli New Shekel"""
     BYN = 36
+    """Belarusian Ruble"""
     KZT = 37
+    """Kazakhstani Tenge"""
     KWD = 38
+    """Kuwaiti Dinar"""
     QAR = 39
+    """Qatari Riyal"""
     CRC = 40
+    """Costa Rican Colón"""
     UYU = 41
+    """Uruguayan Peso"""
     BGN = 42
+    """Bulgarian Lev"""
     HRK = 43
+    """Croatian Kuna"""
     CZK = 44
+    """Czech Koruna"""
     DKK = 45
+    """Danish Krone"""
     HUF = 46
+    """Hungarian Forint"""
     RON = 47
+    """Romanian Leu"""
 
 
 class TradeOfferState(IntEnum):
+    """These are the different states for a trade offer. More information at https://developer.valvesoftware.com/wiki/Steam_Web_API/IEconService#ETradeOfferState"""
     Invalid = 1
+    """Invalid"""
     Active = 2
+    """This trade offer has been sent, neither party has acted on it yet."""
     Accepted = 3
+    """The trade offer was accepted by the recipient and items were exchanged."""
     Countered = 4
+    """The recipient made a counter offer."""
     Expired = 5
+    """The trade offer was not accepted before the expiration date."""
     Canceled = 6
+    """The sender cancelled the offer."""
     Declined = 7
+    """The recipient declined the offer."""
     InvalidItems = 8
+    """Some of the items in the offer are no longer available (indicated by the missing flag in the output)."""
     ConfirmationNeed = 9
+    """The offer hasn't been sent yet and is awaiting email/mobile confirmation. The offer is only visible to the sender."""
     CanceledBySecondaryFactor = 10
+    """Either party canceled the offer via email/mobile. The offer is visible to both parties, even if the sender canceled it before it was sent."""
     StateInEscrow = 11
+    """The trade has been placed on hold. The items involved in the trade have all been removed from both parties' inventories and will be automatically delivered in the future."""
 
 
 class SteamUrl:

--- a/steampy/utils.py
+++ b/steampy/utils.py
@@ -1,3 +1,6 @@
+"""
+Provides utility functions
+"""
 import os
 import re
 import copy
@@ -24,7 +27,6 @@ def login_required(func):
 
     return func_wrapper
 
-
 def text_between(text: str, begin: str, end: str) -> str:
     start = text.index(begin) + len(begin)
     end = text.index(end, start)
@@ -42,6 +44,7 @@ def texts_between(text: str, begin: str, end: str):
             return
 
 
+
 def account_id_to_steam_id(account_id: str) -> str:
     first_bytes = int(account_id).to_bytes(4, byteorder='big')
     last_bytes = 0x1100001.to_bytes(4, byteorder='big')
@@ -53,18 +56,20 @@ def steam_id_to_account_id(steam_id: str) -> str:
 
 
 def calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
-    """Calculate the price including the publisher's fee and the Steam fee.
+    """
+    Calculate the price including the publisher's fee and the Steam fee.
 
-    Arguments:
-        price_net (Decimal): The amount that the seller receives after a market transaction.
-        publisher_fee (Decimal): The Publisher Fee is a game specific fee that is determined and collected by the game
-            publisher. Most publishers have a `10%` fee - `Decimal('0.10')` with a minimum fee of `$0.01`.
-        steam_fee (Decimal): The Steam Transaction Fee is collected by Steam and is used to protect against nominal
-            fraud incidents and cover the cost of development of this and future Steam economy features. The fee is
-            currently `5%` (with a minimum fee of `$0.01`). This fee may be increased or decreased by Steam in the
-            future.
-    Returns:
-        Decimal: Gross price (including fees) - the amount that the buyer pays during a market transaction
+    @param price_net (Decimal): The amount that the seller receives after a market transaction.
+    @param publisher_fee (Decimal): The Publisher Fee is a game specific fee that is determined and collected by the game
+    publisher. Most publishers have a 10% fee - Decimal('0.10') with a minimum fee of $0.01.
+
+    @param steam_fee (Decimal): The Steam Transaction Fee is collected by Steam and is used to protect against nominal
+    fraud incidents and cover the cost of development of this and future Steam economy features. The fee is
+    currently 5% (with a minimum fee of $0.01). This fee may be increased or decreased by Steam in the
+    future.
+
+    @return: Decimal: Gross price (including fees) - the amount that the buyer pays during a market transaction.
+
     """
     price_net *= 100
     steam_fee_amount = int(math.floor(max(price_net * steam_fee, 1)))
@@ -74,18 +79,18 @@ def calculate_gross_price(price_net: Decimal, publisher_fee: Decimal, steam_fee:
 
 
 def calculate_net_price(price_gross: Decimal, publisher_fee: Decimal, steam_fee: Decimal = Decimal('0.05')) -> Decimal:
-    """Calculate the price without the publisher's fee and the Steam fee.
+    """
+    Calculate the price without the publisher's fee and the Steam fee.
 
-    Arguments:
-        price_gross (Decimal): The amount that the buyer pays during a market transaction.
-        publisher_fee (Decimal): The Publisher Fee is a game specific fee that is determined and collected by the game
-            publisher. Most publishers have a `10%` fee - `Decimal('0.10')` with a minimum fee of `$0.01`.
-        steam_fee (Decimal): The Steam Transaction Fee is collected by Steam and is used to protect against nominal
-            fraud incidents and cover the cost of development of this and future Steam economy features. The fee is
-            currently `5%` (with a minimum fee of `$0.01`). This fee may be increased or decreased by Steam in the
-            future.
-    Returns:
-        Decimal: Net price (without fees) - the amount that the seller receives after a market transaction.
+    @param price_gross (Decimal): The amount that the buyer pays during a market transaction.
+    @param publisher_fee (Decimal): The Publisher Fee is a game specific fee that is determined and collected by the game
+    publisher. Most publishers have a 10% fee - Decimal('0.10') with a minimum fee of $0.01.
+    @param steam_fee (Decimal): The Steam Transaction Fee is collected by Steam and is used to protect against nominal
+    fraud incidents and cover the cost of development of this and future Steam economy features. The fee is
+    currently 5% (with a minimum fee of $0.01). This fee may be increased or decreased by Steam in the
+    future.
+
+    @return: Decimal: Net price (without fees) - the amount that the seller receives after a market transaction.
     """
     price_gross *= 100
     estimated_net_price = Decimal(int(price_gross / (steam_fee + publisher_fee + 1)))


### PR DESCRIPTION
Added the following:
- pydoctor to create automatic documentation
- removed currencies list and added a link to currencies docs.
- improved CONTRIBUTING.md file
- removed duplicated license in README.md file

You will need to configure your GitHub page at Settings > Pages (https://github.com/bukson/steampy/settings/pages):

Select "Build and deployment" > "Source", the "Deploy from a branch" value.

In "Branch" select "gh-pages", select "/ (root)" and press the "Save" button.

Now, it will run the GitHub page workflow in the "gh-pages" branch and when it finishes, you just need to go to: https://bukson.github.io/steampy/

If you follow the previous steps, you can see how it looks on my GitHub page (https://albertajuelo.github.io/steampy/index.html).

Future steps to improve the documentation in this project:

- Remove inside the README file all functions and examples and place inside code.
- Add more documentation to each module/class/function.