### PR TITLE
Feature: Raise a TooManyRequests error if get_partner_inventory was used too many times in a row.

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -9,7 +9,7 @@ import requests
 
 from steampy import guard
 from steampy.confirmation import ConfirmationExecutor
-from steampy.exceptions import SevenDaysHoldException, ApiException
+from steampy.exceptions import SevenDaysHoldException, ApiException, TooManyRequests
 from steampy.login import LoginExecutor, InvalidCredentials
 from steampy.market import SteamMarket
 from steampy.models import Asset, TradeOfferState, SteamUrl, GameOptions
@@ -163,7 +163,11 @@ class SteamClient:
         url = '/'.join((SteamUrl.COMMUNITY_URL, 'inventory', partner_steam_id, game.app_id, game.context_id))
         params = {'l': 'english', 'count': count}
 
-        response_dict = self._session.get(url, params=params).json()
+        full_response = self._session.get(url, params=params)
+        response_dict = full_response.json()
+        if full_response.status_code == 429:
+            raise TooManyRequests('Too many requests, try again later.')
+
         if response_dict is None or response_dict.get('success') != 1:
             raise ApiException('Success value should be 1.')
 


### PR DESCRIPTION
Hi,
like someone else mentioned here (https://github.com/bukson/steampy/issues/345#issuecomment-1902117183), I was also wondering why get_parner_inventory sometimes fails. I couldn't find exact numbers on the rate limit that is triggered, but the status code 429 is returned when using it too many times in a row, so the appropriate exception should be thrown.