### PR TITLE
Fix inventory API error by reducing default count

### DIFF
--- a/steampy/client.py
+++ b/steampy/client.py
@@ -163,13 +163,13 @@ class SteamClient:
         return msg in response.text
 
     @login_required
-    def get_my_inventory(self, game: GameOptions, merge: bool = True, count: int = 5000) -> dict:
+    def get_my_inventory(self, game: GameOptions, merge: bool = True, count: int = 2000) -> dict:
         steam_id = self.steam_guard['steamid']
         return self.get_partner_inventory(steam_id, game, merge, count)
 
     @login_required
     def get_partner_inventory(
-        self, partner_steam_id: str, game: GameOptions, merge: bool = True, count: int = 5000,
+        self, partner_steam_id: str, game: GameOptions, merge: bool = True, count: int = 2000,
     ) -> dict:
         url = f'{SteamUrl.COMMUNITY_URL}/inventory/{partner_steam_id}/{game.app_id}/{game.context_id}'
         params = {'l': 'english', 'count': count}


### PR DESCRIPTION
Fixes the ApiException 'Success value should be 1' error when calling get_my_inventory().

**Problem:**
Steam API returns HTTP 400 with null response when requesting count=5000 items, causing the error.

**Solution:**
Reduced default count parameter from 5000 to 2000 in both get_my_inventory() and get_partner_inventory() methods to avoid Steam's rate limiting.

**Testing:**
Verified with CS:GO inventory (730/2) - successfully retrieves items with new limit.

Fixes #391, Fixes #345, Fixes #410